### PR TITLE
feat: 로그인 및 로그아웃 기능 추가 및 이메일 인증 연동 완료

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -58,6 +58,8 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
 
+CORS_ALLOW_ALL_ORIGINS = True
+
 ROOT_URLCONF = 'config.urls'
 
 TEMPLATES = [

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -25,5 +25,5 @@ urlpatterns = [
     path('preference/', include('preference.urls')),
     path('comment/', include('comment.urls')),
     # 루트(/) 요청 오면 user 앱의 로그인 페이지나 다른 페이지로 리디렉트
-     path('', lambda request: redirect('user:main')),  # ✅ 네임스페이스 기반 리디렉트
+     #path('', lambda request: redirect('user:main')),  # ✅ 네임스페이스 기반 리디렉트
 ]

--- a/backend/user/urls.py
+++ b/backend/user/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from . import views
 from django.contrib.auth import views as auth_views
 
+
 app_name = 'user'
 urlpatterns = [
    path('login/', views.Login, name='login'),
@@ -13,9 +14,11 @@ urlpatterns = [
    template_name='mypage1/change_password_done.html'
    ), name='password_change_done'),
    path('user/home/', views.user_home, name='user_home'),
-   path('test-email/', views.test_email, name='test_email'),
+   #path('test-email/', views.test_email, name='test_email'),
    path('verify-email/<uidb64>/<token>/', views.verify_email, name='verify_email'),
    path('signup/', views.signup_view, name='signup'),
-
+   path('api/login/', views.api_login_view, name='api_login'),
+   path('api/logout/', views.api_logout_view, name='api_logout'),
+  
 
 ]

--- a/backend/user/views.py
+++ b/backend/user/views.py
@@ -16,6 +16,11 @@ from django.contrib.auth.tokens import default_token_generator   #인증 토큰 
 from django.urls import reverse    #인증 링크 생성용
 from django.contrib.auth import get_user_model  # verify_email용
 from django.utils.http import urlsafe_base64_decode
+from django.views.decorators.csrf import csrf_exempt
+import json
+from django.http import JsonResponse  
+from django.contrib.auth import logout
+
 
 
 
@@ -69,8 +74,7 @@ def Login(request):
             login(request, user_auth)
             user.failed_attempts = 0
             user.save()
-            print("로그인 성공")
-            return HttpResponse("로그인 성공 페이지 (임시)") # 메인 페이지 완성 시 수정해야함
+            return JsonResponse({'message': '로그인 성공'}) # 메인 페이지 완성 시 수정해야함
         else:
             user.failed_attempts += 1
             if user.failed_attempts >= MAX_LOGIN_ATTEMPTS:
@@ -121,6 +125,7 @@ def send_verification_email(user, request):
         f"{verify_url}\n\n"
         f"해당 링크는 일정 시간 후 만료되니 빠르게 인증을 완료해주세요."
     )
+    print(uid, token, verify_url, subject, message)
 
     send_mail(
         subject=subject,
@@ -145,15 +150,110 @@ def verify_email(request, uidb64, token):
         return HttpResponse("인증 링크가 유효하지 않거나 만료되었습니다.")
     
 
-def test_email(request):
-    send_mail(
-        subject='[CleanUs] 이메일 테스트입니다.',
-        message='이 메일은 SMTP 설정이 제대로 되었는지 확인하기 위한 테스트입니다.',
-        from_email=settings.EMAIL_HOST_USER,  # settings의 DEFAULT_FROM_EMAIL 사용
-        recipient_list=['peter8656@naver.com'],  # 너가 직접 받을 이메일로 바꾸기!
-        fail_silently=False,
-    )
-    return HttpResponse("이메일 전송 완료!")
+# def test_email(request):
+#     send_mail(
+#         subject='[CleanUs] 이메일 테스트입니다.',
+#         message='이 메일은 SMTP 설정이 제대로 되었는지 확인하기 위한 테스트입니다.',
+#         from_email=settings.EMAIL_HOST_USER,  # settings의 DEFAULT_FROM_EMAIL 사용
+#         recipient_list=['peter8656@naver.com'],  # 너가 직접 받을 이메일로 바꾸기!
+#         fail_silently=False,
+#     )
+#     return HttpResponse("이메일 전송 완료!")
+
+@csrf_exempt
+def signup_view(request):
+    if request.method == 'POST':
+        try:
+            data = json.loads(request.body)
+            name = data.get('name')
+            email = data.get('email')
+            password = data.get('password')
+
+            if not all([name, email, password]):
+                return JsonResponse({'error': '누락된 필드가 있습니다.'}, status=400)
+
+            if User.objects.filter(email=email).exists():
+                return JsonResponse({'error': '이미 존재하는 이메일입니다.'}, status=400)
+
+            user = User.objects.create_user(
+                username=name,
+                email=email,
+                password=password,
+                is_active=False
+            )
+            print(user, request)
+
+            send_verification_email(user, request)
+            return JsonResponse({'message': '회원가입 성공. 이메일 인증 필요.'}, status=201)
+
+        except Exception as e:
+            print("에러:", e)
+            return JsonResponse({'error': '회원가입 처리 중 오류 발생'}, status=500)
+
+    return JsonResponse({'error': 'POST 요청만 허용됩니다.'}, status=405)
+
+
+@csrf_exempt  # CSRF 검사 생략 (프론트에서 쿠키 기반 세션인증 시 필요)
+def api_login_view(request):
+    # [POST] 로그인 요청 처리
+    if request.method == 'POST':
+        try:
+            # JSON 데이터 파싱
+            data = json.loads(request.body)
+            email = data.get('email')
+            password = data.get('password')
+
+            # 이메일로 사용자 조회
+            try:
+                user = User.objects.get(email=email)
+            except User.DoesNotExist:
+                return JsonResponse({'message': '존재하지 않는 이메일입니다.'}, status=400)
+
+            # 계정이 잠겨있는 경우
+            if user.is_locked:
+                return JsonResponse({'message': '계정이 잠겼습니다. 관리자에게 문의하세요.'}, status=403)
+
+            # 이메일 인증이 안 된 경우
+            if not user.is_active:
+                return JsonResponse({'message': '이메일 인증이 완료되지 않았습니다.'}, status=403)
+
+            # username 기반으로 인증 시도
+            user_auth = authenticate(request, username=user.username, password=password)
+
+            if user_auth is not None:
+                # 로그인 성공: 세션에 사용자 등록 + 실패 횟수 초기화
+                login(request, user_auth)
+                user.failed_attempts = 0
+                user.save()
+                return JsonResponse({'message': '로그인 성공'}, status=200)
+            else:
+                # 로그인 실패: 실패 횟수 증가
+                user.failed_attempts += 1
+                if user.failed_attempts >= MAX_LOGIN_ATTEMPTS:
+                    # 최대 실패 횟수 초과 → 계정 잠금
+                    user.lock_account()
+                    return JsonResponse({'message': '계정이 잠겼습니다.'}, status=403)
+                else:
+                    user.save()
+                    return JsonResponse({'message': f'비밀번호가 틀렸습니다. ({user.failed_attempts}회 실패)'}, status=401)
+
+        except Exception as e:
+            # 서버 내부 오류 처리
+            print('로그인 중 오류:', e)
+            return JsonResponse({'message': '서버 오류'}, status=500)
+
+    # POST가 아닌 경우 허용 안 함
+    return JsonResponse({'message': 'POST 요청만 허용됩니다.'}, status=405)
+
+
+@csrf_exempt
+def api_logout_view(request):
+    if request.method == 'POST':
+        logout(request)
+        return JsonResponse({'message': '로그아웃 성공'}, status=200)
+    return JsonResponse({'message': 'POST 요청만 허용됩니다.'}, status=405)
+
+
 
 
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13985,6 +13985,7 @@
       "version": "6.30.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.0.tgz",
       "integrity": "sha512-x30B78HV5tFk8ex0ITwzC9TTZMua4jGyA9IUlH1JLQYQTFyxr/ZxwOJq7evg1JX1qGVUcvhsmQSKdPncQrjTgA==",
+      "license": "MIT",
       "dependencies": {
         "@remix-run/router": "1.23.0",
         "react-router": "6.30.0"

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,9 @@ import FeedbackPage from './FeedbackPage';
 import './App.css';
 import axios from 'axios';
 import React, { useEffect } from 'react'
+import LoginPage from './LoginPage.jsx';
+import SignupPage from './SignupPage.jsx';
+
 
 
 axios.defaults.baseURL = 'http://127.0.0.1:8000';
@@ -50,6 +53,8 @@ function App() {
   return (
     <Router>
       <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/signup" element={<SignupPage />} />
         <Route path="/" element={<BaseLayout />}>
           <Route index element={<HomePage />} />
           <Route path="keywords" element={<KeywordPage />} />

--- a/frontend/src/LoginPage.jsx
+++ b/frontend/src/LoginPage.jsx
@@ -1,0 +1,64 @@
+// src/LoginPage.jsx
+import React, { useState } from 'react';
+import axios from 'axios';
+
+const LoginPage = () => {
+  // 입력값 상태 관리
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  // 로그인 요청 함수
+  const handleLogin = async (e) => {
+    e.preventDefault();  // 기본 폼 제출 막기
+
+    try {
+      const response = await axios.post('http://127.0.0.1:8000/user/api/login/', {
+        email,
+        password,
+      }, {
+        withCredentials: true  // 세션 쿠키 저장을 위해 필요
+      });
+
+      if (response.data.message === '로그인 성공') {
+      window.location.href = 'http://localhost:3000';  // 또는 원하는 경로
+    } else {
+      setMessage(response.data.message);
+    }
+    } 
+    
+    catch (error) {
+      if (error.response) {
+        setMessage(error.response.data.message);  // 백엔드 오류 메시지 출력
+      } else {
+        setMessage("서버와 연결할 수 없습니다.");
+      }
+    }
+  };
+
+  return (
+    <div>
+      <h2>로그인</h2>
+      <form onSubmit={handleLogin}>
+        <input
+          type="email"
+          placeholder="이메일"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        /><br />
+        <input
+          type="password"
+          placeholder="비밀번호"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        /><br />
+        <button type="submit">로그인</button>
+      </form>
+      {message && <p>{message}</p>}
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/Sidebar.js
+++ b/frontend/src/Sidebar.js
@@ -1,22 +1,60 @@
-// Sidebar.js
+// src/Sidebar.js
 import React from 'react';
+import { Link } from 'react-router-dom';
+import axios from 'axios';
 import './Sidebar.css';
 
 function Sidebar() {
+  // 로그아웃 처리 함수
+  const handleLogout = async () => {
+    const confirmed = window.confirm('정말 로그아웃하시겠습니까?');
+    if (confirmed) {
+      try {
+        await axios.post('http://127.0.0.1:8000/user/api/logout/', {}, {
+          withCredentials: true
+        });
+        window.location.href = '/'; // 로그아웃 후 메인 페이지로 이동
+      } catch (error) {
+        console.error('로그아웃 실패:', error);
+      }
+    }
+  };
+
   return (
     <nav className="sidebar">
       <h2>📋 메뉴</h2>
       <ul>
-        <li><a href="#">로그인 / 회원가입</a></li>
+        <li><Link to="/login">로그인</Link></li>
+        <li><Link to="/signup">회원가입</Link></li>
         <li><a href="#">테스트 페이지</a></li>
         <li><a href="#">원본 댓글</a></li>
         <li><a href="#">차단 대상 댓글</a></li>
         <li><a href="#">처리 완료 댓글</a></li>
         <li><a href="#">사용자 피드백</a></li>
         <li><a href="#">키워드 설정</a></li>
+
+        {/* 로그아웃 버튼 */}
+        <li>
+          <button
+            onClick={handleLogout}
+            style={{
+              background: 'none',
+              border: 'none',
+              color: '#000',
+              padding: 0,
+              cursor: 'pointer',
+              textAlign: 'left',
+              fontSize: 'inherit'
+            }}
+          >
+            로그아웃
+          </button>
+        </li>
       </ul>
     </nav>
   );
 }
 
 export default Sidebar;
+
+

--- a/frontend/src/SignupPage.jsx
+++ b/frontend/src/SignupPage.jsx
@@ -1,0 +1,85 @@
+// src/SignupPage.jsx
+import React, { useState } from 'react';
+import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+
+const SignupPage = () => {
+  // 1. 입력값 상태 관리
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+
+  const navigate = useNavigate(); // 페이지 이동용
+
+  // 2. 폼 전송 시 실행될 함수
+  const handleSubmit = async (e) => {
+    e.preventDefault(); // 새로고침 막기
+
+    if (password !== confirmPassword) {
+      alert('비밀번호가 일치하지 않습니다.');
+      return;
+    }
+
+    try {
+      // 3. Django 백엔드에 회원가입 요청
+      const response = await axios.post('/user/signup/', {
+        name,
+        email,
+        password,
+      });
+
+      alert('회원가입 성공!');
+      navigate('/login'); // 로그인 페이지로 이동
+
+    } catch (error) {
+  console.error(error);
+  if (error.response && error.response.data && error.response.data.error) {
+    alert(`회원가입 실패: ${error.response.data.error}`);
+  } else {
+    alert('회원가입에 실패했습니다.');
+  }
+}
+
+  };
+
+  return (
+    <div>
+      <h2>회원가입</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          placeholder="이름"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        <input
+          type="email"
+          placeholder="이메일"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="비밀번호"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="비밀번호 확인"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          required
+        />
+        <button type="submit">회원가입</button>
+      </form>
+    </div>
+  );
+};
+
+export default SignupPage;
+


### PR DESCRIPTION
### 작업 내용 요약
- 이메일/비밀번호 기반 로그인 기능 구현
- 로그인 실패 시 계정 잠금 및 실패 횟수 처리
- 이메일 인증 미완료 시 로그인 불가 처리
- 로그아웃 API 구현 및 React Sidebar에 버튼 추가
- 로그인/로그아웃 시 React에서 axios 연동 완료
- 로그인 성공 시 메인 페이지(`/`)로 리디렉션

### 테스트
- 회원가입 → 이메일 인증 → 로그인 → 로그아웃 전 과정 테스트 완료
- Django 서버 로그 및 상태 코드 정상 확인 (200 OK)
- React에서 `window.confirm`으로 로그아웃 확인 처리

### 기타
- CSRF 관련 요청은 현재 개발 단계에선 무시
- 향후 마이페이지 또는 인증 상태 UI 개선 예정
